### PR TITLE
Add pagination and a link back to the home page when user clicks the logo of the site

### DIFF
--- a/front/src/components/buildings/BuildingGrid.js
+++ b/front/src/components/buildings/BuildingGrid.js
@@ -15,6 +15,7 @@ function BuildingGrid() {
 	return (
 		<div>
 			<h2>Browse Architecture:</h2>
+// 		you definitely want to add pagination here 
 			<div className="buildingStyle">
 				{buildings.map((building) => (
 					<BuildingUnit key={building._id} building={building} />

--- a/front/src/components/layout/Navbar.js
+++ b/front/src/components/layout/Navbar.js
@@ -13,6 +13,7 @@ function Navbar({ icon, title }) {
 	return (
 		<nav className="navbar bg-primary">
 			<h1>
+// 				I would add a link to the homepage whenever the logo is placed in the nav bar
 				<img
 					src={icon}
 					alt="logo"


### PR DESCRIPTION
1.Pagination edit suggestion
![image](https://user-images.githubusercontent.com/24192481/205817181-e3675ec7-4e71-4484-b117-4c77d92c972b.png)
The red circle indicate a need for pagination. Most pages in industry limit how many results are showed per page
2. The logo in the nav bar should be clickable and link back to the home page
This reduces mental burden on the user in terms of navigating through the site
